### PR TITLE
Never change the window's width

### DIFF
--- a/autoload/augment/chat.vim
+++ b/autoload/augment/chat.vim
@@ -55,6 +55,7 @@ function! augment#chat#OpenChatPanel() abort
     if exists('&winfixbuf')
         setlocal winfixbuf       " Keep buffer in window when splitting
     endif
+    setlocal winfixwidth         " Never change the window's width
     setlocal bufhidden=hide      " When buffer is abandoned, hide it
     setlocal nobuflisted         " Hide from :ls
     setlocal wrap                " Wrap long lines


### PR DESCRIPTION
Keep the width of the Augment chat window always the same. This will prevent the window from changing size when you delete another window, for example, and Vim rebalances the remaining windows.