### PR TITLE
Add :Augment help [command] subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This file documents the notable changes for each stable version of the Augment
 Vim plugin. The following list is not necessarily comprehensive, but should
 include any changes that may impact the user experience.
 
+## Unreleased
+
+- Add the `:Augment help [command]` command, which lists the available commands
+  or shows more detailed help for a specific command.
+
 ## 0.25.1
 
 - Deprecate the `Enable` and `Disable` commands in favor of the

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The following commands are provided:
 :Augment chat          " Send a chat message to Augment AI
 :Augment chat-new      " Start a new chat conversation
 :Augment chat-toggle   " Toggle the chat panel visibility
+:Augment help          " List the available commands, or `:Augment help <command>` for details
 ```
 
 ## Workspace Folders

--- a/autoload/augment.vim
+++ b/autoload/augment.vim
@@ -233,6 +233,90 @@ function! s:CommandChatToggle(range, args) abort
     call augment#chat#Toggle()
 endfunction
 
+" Help text for the available commands. The order of this list determines the
+" order shown by `:Augment help`. Each entry has a usage string (shown in the
+" detail header), a one-line summary (shown in the command list), and a list of
+" detail lines (shown by `:Augment help <command>`).
+let s:command_help = [
+    \ {'name': 'status', 'usage': 'status', 'summary': 'View the current status of the plugin.', 'detail': [
+    \     'View the current status of the plugin, including whether you are',
+    \     'signed in and the syncing progress of any configured workspace folders.',
+    \ ]},
+    \ {'name': 'signin', 'usage': 'signin', 'summary': 'Sign in to Augment.', 'detail': [
+    \     'Authenticate with the Augment service using OAuth. This is required',
+    \     'before using the plugin for the first time.',
+    \ ]},
+    \ {'name': 'signout', 'usage': 'signout', 'summary': 'Sign out of Augment.', 'detail': [
+    \     'Sign out of Augment.',
+    \ ]},
+    \ {'name': 'log', 'usage': 'log', 'summary': 'View the plugin log.', 'detail': [
+    \     'View the plugin log. This is useful for debugging.',
+    \ ]},
+    \ {'name': 'chat', 'usage': 'chat [message]', 'summary': 'Send a chat message to Augment AI.', 'detail': [
+    \     'Start a chat with Augment AI. In visual mode, the selected text will',
+    \     'be included in the chat request. If no message is provided, you will',
+    \     'be prompted to enter one.',
+    \ ]},
+    \ {'name': 'chat-new', 'usage': 'chat-new', 'summary': 'Start a new chat conversation.', 'detail': [
+    \     'Start a new chat conversation with Augment AI, clearing the history',
+    \     'from your context.',
+    \ ]},
+    \ {'name': 'chat-toggle', 'usage': 'chat-toggle', 'summary': 'Toggle the chat panel visibility.', 'detail': [
+    \     'Open or close the chat conversation window. The conversation is',
+    \     'preserved while the window is closed and can be reopened with the',
+    \     'same command.',
+    \ ]},
+    \ {'name': 'help', 'usage': 'help [command]', 'summary': 'Show help for Augment commands.', 'detail': [
+    \     'Show help for Augment commands. With no argument, list all available',
+    \     'commands with a short description. With a command name, show detailed',
+    \     'help for that command.',
+    \ ]},
+    \ {'name': 'enable', 'usage': 'enable', 'summary': '(deprecated) See g:augment_disable_completions.', 'detail': [
+    \     'Deprecated. Use the g:augment_disable_completions option instead,',
+    \     'which disables inline completions without affecting chat. See',
+    \     '":help g:augment_disable_completions" for more details.',
+    \ ]},
+    \ {'name': 'disable', 'usage': 'disable', 'summary': '(deprecated) See g:augment_disable_completions.', 'detail': [
+    \     'Deprecated. Use the g:augment_disable_completions option instead,',
+    \     'which disables inline completions without affecting chat. See',
+    \     '":help g:augment_disable_completions" for more details.',
+    \ ]},
+    \ ]
+
+" Show help for the available commands. With no argument, list all commands;
+" with a command name, show detailed help for that command.
+function! s:CommandHelp(range, args) abort
+    let topic = empty(a:args) ? '' : split(a:args)[0]
+
+    if empty(topic)
+        echohl Title
+        echo 'Augment commands'
+        echohl None
+        for entry in s:command_help
+            echo printf('  :Augment %-12s %s', entry.name, entry.summary)
+        endfor
+        echo 'Run ":Augment help <command>" for more details about a command.'
+        return
+    endif
+
+    for entry in s:command_help
+        " Note that ==? is case-insensitive comparison
+        if topic ==? entry.name
+            echohl Title
+            echo ':Augment ' . entry.usage
+            echohl None
+            for line in entry.detail
+                echo '    ' . line
+            endfor
+            return
+        endif
+    endfor
+
+    echohl WarningMsg
+    echo 'Augment: Unknown command: "' . topic . '". Run ":Augment help" to list available commands.'
+    echohl None
+endfunction
+
 " Handle user commands
 let s:command_handlers = {
     \ 'log': function('s:CommandLog'),
@@ -244,6 +328,7 @@ let s:command_handlers = {
     \ 'chat': function('s:CommandChat'),
     \ 'chat-new': function('s:CommandChatNew'),
     \ 'chat-toggle': function('s:CommandChatToggle'),
+    \ 'help': function('s:CommandHelp'),
     \ }
 
 function! augment#Command(range, args) abort range
@@ -252,11 +337,12 @@ function! augment#Command(range, args) abort range
         return
     endif
 
-    " If the plugin failed to initialize, only allow status and log commands
+    " If the plugin failed to initialize, only allow status, log, and help
+    " commands
     let command = split(a:args)[0]
     if (!exists('g:augment_initialized') || !g:augment_initialized)
-                \ && command !=# 'status' && command !=# 'log'
-        call augment#DisplayError('The Augment plugin failed to initialize. Only `:Augment status` and `:Augment log` commands are available.')
+                \ && command !=# 'status' && command !=# 'log' && command !=# 'help'
+        call augment#DisplayError('The Augment plugin failed to initialize. Only `:Augment status`, `:Augment log`, and `:Augment help` commands are available.')
         return
     endif
 

--- a/doc/augment.txt
+++ b/doc/augment.txt
@@ -54,6 +54,12 @@ The following commands are provided:
 `:Augment chat-toggle`
     Open/close the chat conversation window.
 
+                                                            *:Augment_help*
+`:Augment help [command]`
+    Show help for the Augment commands. With no argument, list all available
+    commands with a short description. With a command name, show more detailed
+    help for that command, for example `:Augment help chat`.
+
 
 ------------------------------------------------------------------------------
 Options                                                   *augment-options*


### PR DESCRIPTION
## Summary

Adds a `:Augment help [command]` subcommand, as requested in #32.

- `:Augment help` lists every available command with a one-line description.
- `:Augment help <command>` shows more detailed inline help for that command (e.g. `:Augment help chat`). An unknown command produces a friendly error pointing back to `:Augment help`.
- The deprecated `enable` / `disable` commands are listed and clearly marked `(deprecated)`, pointing users to the `g:augment_disable_completions` option.
- Like `status` and `log`, `help` works even when the plugin fails to initialize.
- `augment#CommandComplete` automatically picks up `help` (it returns the keys of the command-handler dict), so tab completion includes it.

## Implementation

- New `s:CommandHelp(range, args)` handler and an ordered `s:command_help` data structure in `autoload/augment.vim`, following the existing `s:CommandXxx` style and using `echohl` highlight groups.
- `help` added to the `s:command_handlers` dict and to the pre-init allow-list in `augment#Command`.

## Docs

- `doc/augment.txt`: documented the new `:Augment help` command.
- `README.md`: added `help` to the command list.
- `CHANGELOG.md`: added an Unreleased entry.

## Testing

The repository has no test framework, so this was verified manually with headless `vim -es` and `nvim --headless` smoke checks:

- `:Augment help` lists all commands (deprecated ones marked).
- `:Augment help chat` / `:Augment help enable` show inline detail.
- Case-insensitive lookup (`:Augment help CHAT`) works.
- `:Augment help bogus` shows the friendly unknown-command error.
- `:Augment help` works with the plugin in an uninitialized state.
- `augment#CommandComplete` includes `help`.

Fixes #32
